### PR TITLE
Updated southpaw75.keymap

### DIFF
--- a/config/southpaw75.keymap
+++ b/config/southpaw75.keymap
@@ -5,37 +5,39 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/ext_power.h>
+#include <dt-bindings/zmk/keys.h>
 
 / {
     keymap {
         compatible = "zmk,keymap";
 
         default_layer {
-// ------------------------------------------------------------------------------------------------------------------
-// | NUM |  /  |  *  |  -  | ESC |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  | DEL | BKSP |
-// |  7  |  8  |  9  |  +  | TAB  |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |    \    |
-// |  4  |  5  |  6  |     | CAPS  |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |  '  |     ENTER    |
-// |  1  |  2  |  3  | ENT |  SHIFT  |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |  SHIFT   | MO(2) |
-// |     0     |  .  |     |  CTL  |  WIN  |  ALT  |             SPACE              |  ALT  | MO(1) |  WIN  | CTRL  |
-// ------------------------------------------------------------------------------------------------------------------
+            // ------------------------------------------------------------------------------------------------------------------
+            // | NUM |  /  |  *  |  -  | ESC |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  |  0  |  -  |  =  | DEL | BKSP |
+            // |  7  |  8  |  9  |  +  | TAB  |  Q  |  W  |  E  |  R  |  T  |  Y  |  U  |  I  |  O  |  P  |  [  |  ]  |    \    |
+            // |  4  |  5  |  6  |     | CAPS  |  A  |  S  |  D  |  F  |  G  |  H  |  J  |  K  |  L  |  ;  |  '  |     ENTER    |
+            // |  1  |  2  |  3  | ENT |  SHIFT  |  Z  |  X  |  C  |  V  |  B  |  N  |  M  |  ,  |  .  |  /  |  SHIFT   | MO(2) |
+            // |     0     |  .  |     |  CTL  |  WIN  |  ALT  |             SPACE              |  ALT  | MO(1) |  WIN  | CTRL  |
+            // ------------------------------------------------------------------------------------------------------------------
+
             bindings = <
-                &kp KP_NLCK &kp KP_DIVIDE &kp KP_MULTIPLY &kp KP_MINUS   &kp ESC         &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 &kp   N8  &kp  N9 &kp  N0  &kp MINUS &kp EQUAL &kp DEL &kp BSPC
-                &kp N7      &kp N8        &kp N9          &kp KP_PLUS    &kp TAB          &kp Q  &kp W  &kp E  &kp R  &kp T  &kp Y  &kp U  &kp   I   &kp  O  &kp   P  &kp LBKT &kp RBKT  &kp RET
-                &kp N4      &kp N5        &kp N6                         &kp CLCK          &kp A  &kp S  &kp D  &kp F  &kp G  &kp H  &kp J  &kp   K   &kp  L  &kp SEMI &kp SQT &kp NUHS
-                &kp N1      &kp N2        &kp N3          &kp KP_ENTER   &kp LSHFT &kp NUBS &kp Z  &kp X  &kp C  &kp V  &kp B  &kp N  &kp M  &kp COMMA &kp DOT &kp FSLH        &kp RSHFT &mo  2
-                    &kp N0              &kp DOT                        &kp LCTRL &kp LGUI &kp LALT               &kp SPACE                 &kp  RALT  &mo  1  &kp  RGUI  &kp  RCTRL
+&kp KP_NLCK      &kp KP_DIVIDE    &kp KP_MULTIPLY   &kp KP_MINUS  &kp ESC       &kp N1     &kp N2        &kp N3          &kp N4          &kp N5           &kp N6  &kp N7  &kp N8     &kp N9      &kp N0     &kp MINUS  &kp EQUAL  &kp DEL               &kp BSPC
+&kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9   &kp KP_PLUS   &kp TAB       &kp Q      &kp W         &kp E           &kp R           &kp T            &kp Y   &kp U   &kp I      &kp O       &kp P      &kp LBKT   &kp RBKT   &kp NON_US_BACKSLASH
+&kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6   &kp CLCK      &kp A         &kp S      &kp D         &kp F           &kp G           &kp H            &kp J   &kp K   &kp L      &kp SEMI    &kp SQT    &kp ENTER
+&kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3   &kp KP_ENTER  &kp LSHFT     &kp Z      &kp X         &kp C           &kp V           &kp B            &kp N   &kp M   &kp COMMA  &kp PERIOD  &kp SLASH  &kp UP     &kp RSHFT
+&kp KP_NUMBER_0  &kp PERIOD       &kp LEFT_CONTROL  &mo 1         &kp LEFT_ALT  &kp SPACE  &kp LEFT_WIN  &kp LEFT_ARROW  &kp DOWN_ARROW  &kp RIGHT_ARROW
             >;
         };
 
         fn_layer {
             bindings = <
-                &trans      &trans        &trans          &trans         &kp GRAVE  &kp F1     &kp F2     &kp F3     &kp F4     &kp F5     &kp F6     &kp F7     &kp F8     &kp F9     &kp F10    &kp F11    &kp F12    &kp F13    &bootloader
-                &trans      &trans        &trans          &trans         &trans         &bt BT_CLR &none      &none      &none      &none      &none      &none      &none      &none      &none      &none      &none      &sys_reset
-                &trans      &trans        &trans          &trans         &trans           &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4 &kp LEFT   &kp DOWN   &kp UP   &kp RIGHT   &none      &none      &trans
-                &trans      &trans        &trans          &trans         &trans &trans         &none      &none      &none      &none      &none      &none      &none      &none      &none      &none          &trans     &trans
-                &trans      &trans        &trans          &trans         &trans       &trans       &trans                                      &trans                                      &trans     &trans     &trans     &trans
+&ext_power EP_TOG  &trans  &trans  &trans  &kp GRAVE  &kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6  &kp F7  &kp F8  &kp F9  &kp F10  &kp F11  &kp F12  &kp F13     &bootloader
+&trans             &trans  &trans  &trans  &trans     &bt BT_CLR    &none         &none         &none         &none         &none   &none   &none   &none   &none    &none    &none    &sys_reset
+&trans             &trans  &trans  &trans  &trans     &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none   &none   &none   &none   &none    &none
+&trans             &trans  &trans  &trans  &trans     &trans        &trans        &none         &none         &none         &none   &none   &none   &none   &none    &none    &none
+&trans             &trans  &trans  &trans  &trans     &trans        &trans        &trans        &trans        &trans
             >;
         };
     };


### PR DESCRIPTION
<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
